### PR TITLE
友達申請承認機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Things you may want to cover:
 | friend_id           | integer | null: false, foreign_key: true |
 
 ### Association
-- belong_to :user
+- belongs_to :user
 
 
 ## user_relationsテーブル
@@ -52,7 +52,7 @@ Things you may want to cover:
 | friend_introduction | text    |                                |
 
 ### Association
-- belong_to :user
+- belongs_to :user
 
 
 ## rooms テーブル

--- a/app/assets/stylesheets/user.css
+++ b/app/assets/stylesheets/user.css
@@ -181,3 +181,9 @@
 .main {
   margin: 0 20vw;
 }
+
+.main li {
+  text-decoration: none;
+  color: #333333;
+  list-style: none;
+}

--- a/app/assets/stylesheets/user_relations.scss
+++ b/app/assets/stylesheets/user_relations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the user_relations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/user_relations_controller.rb
+++ b/app/controllers/user_relations_controller.rb
@@ -1,0 +1,25 @@
+class UserRelationsController < ApplicationController
+  def new
+    @user_relation = UserRelation.new
+  end
+
+  def create
+    # 申請元・申請先それぞれで友達の紐付け処理
+    UserRelation.create(user_relation_params_first)
+    UserRelation.create(user_relation_params_second)
+    # 友達申請テーブルのレコード削除処理
+    id = FriendApproval.where(user_id: params[:user_id].to_i, friend_id: current_user.id).pluck(:id)[0]
+    friend_approval = FriendApproval.find(id.to_s)
+    friend_approval.destroy
+    redirect_to root_path
+  end
+
+  private
+  def user_relation_params_first
+    params.permit(:user_id, :friend_id).merge(user_id: current_user.id, friend_id: params[:user_id].to_i)
+  end
+
+  def user_relation_params_second
+    params.permit(:user_id, :friend_id).merge(user_id: params[:user_id].to_i, friend_id: current_user.id)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,6 @@ class UsersController < ApplicationController
   def index
     @users = User.all
     @friend_approvals = FriendApproval.all
-    # @confirm_approval = FriendApproval.exists?(user_id: current_user.id, friend_id: @user.id)
+    @user_relations = UserRelation.all
   end
 end

--- a/app/helpers/user_relations_helper.rb
+++ b/app/helpers/user_relations_helper.rb
@@ -1,0 +1,2 @@
+module UserRelationsHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,4 +14,5 @@ class User < ApplicationRecord
   validates :birthday, presence: true
 
   has_many :friend_approvals
+  has_many :user_relations
 end

--- a/app/models/user_relation.rb
+++ b/app/models/user_relation.rb
@@ -1,0 +1,3 @@
+class UserRelation < ApplicationRecord
+  belong_to :user
+end

--- a/app/models/user_relation.rb
+++ b/app/models/user_relation.rb
@@ -1,3 +1,3 @@
 class UserRelation < ApplicationRecord
-  belong_to :user
+  belongs_to :user
 end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -20,14 +20,29 @@
     <h3>＜共通の友達一覧＞</h3>
       <p>※一覧表示準備中※<br>もうしばらくお待ちください。。</p>
     <h3>＜友達一覧＞</h3>
-      <p>※一覧表示準備中※<br>もうしばらくお待ちください。。</p>
+    <ul class='friend-list'>
+    <% @user_relations.each do |user_relation| %>
+      <% if current_user.id == user_relation.user_id %>
+        <li>
+          <% @users.each do |user| %>
+            <% if user.id == user_relation.friend_id %>
+              <p id= user_relations.friend_id>
+                <%= user.last_name %> <%= user.first_name %>
+                <%= link_to '他己紹介を書く', '#', class:"#" %>
+              </p>
+            <% end %>
+          <% end %>
+        </li>
+      <% end %>
+    <% end %>
+    </ul>
     <h3>＜友達リクエストされた友人一覧＞</h3>
     <ul class='friend-request-list'>
     <% @users.each do |user| %>
       <% if @friend_approvals.exists?(user_id: user.id, friend_id: current_user.id) %>
         <li>
           <p id= user.id><%= user.nickname %>
-            <%= link_to '承認する', '#', method: :post, class:"approve-friend-btn" %>
+            <%= link_to '承認する', user_user_relations_path(user_id: user.id, friend_id: current_user.id), method: :post, class:"approve-friend-btn" %>
             <%= link_to '却下する', user_friend_approval_path(user_id: user.id, id: @friend_approvals.where(user_id: user.id, friend_id: current_user.id).pluck(:id)), method: :delete, class:"reject-friend-btn" %>
           </p>
         </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,6 @@ Rails.application.routes.draw do
   root to: 'users#index'
   resources :users, only: [:index] do
     resources :friend_approvals, only: [:create, :destroy]
+    resources :user_relations, only: [:create]
   end
 end

--- a/db/migrate/20200924021209_create_user_relations.rb
+++ b/db/migrate/20200924021209_create_user_relations.rb
@@ -1,0 +1,11 @@
+class CreateUserRelations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :user_relations, id: :integer do |t|
+      t.integer :user_id,   null: false, foreign_key: true
+      t.integer :friend_id, null: false, foreign_key: true
+      t.text :friend_introduction
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_21_093859) do
+ActiveRecord::Schema.define(version: 2020_09_24_021209) do
 
   create_table "friend_approvals", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
     t.integer "friend_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "user_relations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "friend_id", null: false
+    t.text "friend_introduction"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/factories/user_relations.rb
+++ b/spec/factories/user_relations.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user_relation do
+    
+  end
+end

--- a/spec/helpers/user_relations_helper_spec.rb
+++ b/spec/helpers/user_relations_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the UserRelationsHelper. For example:
+#
+# describe UserRelationsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe UserRelationsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_relation_spec.rb
+++ b/spec/models/user_relation_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe UserRelation, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/user_relations_request_spec.rb
+++ b/spec/requests/user_relations_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "UserRelations", type: :request do
+
+end


### PR DESCRIPTION
#what
友達申請承認機能を実装しました。
friend_approvalテーブルから対象のレコードを削除のうえ、user_relationテーブルに2レコード作成します。
リクエスト承認後はトップページの友達一覧に表示されます。

#why
友達リクエストを承認することでユーザー同士の友達関係を作るため。
申請データは友達承認後は不要のため、削除しています。