### PR TITLE
他己紹介投稿機能と紹介文表示の実装

### DIFF
--- a/app/controllers/user_relations_controller.rb
+++ b/app/controllers/user_relations_controller.rb
@@ -14,6 +14,20 @@ class UserRelationsController < ApplicationController
     redirect_to root_path
   end
 
+  def edit
+    @user_relation = UserRelation.find(params[:id])
+    @users = User.all
+
+  end
+
+  def update
+    @user_relation = UserRelation.find(params[:id])
+    if @user_relation.update(user_relation_params)
+      binding.pry
+      redirect_to root_path
+    end
+  end
+
   private
   def user_relation_params_first
     params.permit(:user_id, :friend_id).merge(user_id: current_user.id, friend_id: params[:user_id].to_i)
@@ -21,5 +35,10 @@ class UserRelationsController < ApplicationController
 
   def user_relation_params_second
     params.permit(:user_id, :friend_id).merge(user_id: params[:user_id].to_i, friend_id: current_user.id)
+  end
+
+  def user_relation_params
+    params.require(:user_relation).permit(:friend_introduction).merge(user_id: current_user.id, id: params[:id].to_i, friend_introduction: params[:user_relation][:friend_intrduction] )
+    # friend_intrduction: params[:user_relation]
   end
 end

--- a/app/views/user_relations/edit.html.erb
+++ b/app/views/user_relations/edit.html.erb
@@ -1,0 +1,29 @@
+<header class='top-page-header'>
+  <div class='search-bar-contents'>
+    <%= link_to image_tag("contouch_logo1.png", class:"contouch-icon"), "/" %>
+  </div>
+  <div class='nav'>
+    <ul class='lists-right'>
+      <% if user_signed_in? %>
+        <li><%= link_to current_user.nickname, "#", class: "header-list user-nickname" %></li>
+        <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: "header-list logout" %></li>
+      <% else %>
+        <li><%= link_to 'ログイン', new_user_session_path, class: "header-list login" %></li>
+        <li><%= link_to '新規登録', new_user_registration_path, class: "header-list sign-up" %></li>
+      <% end %>
+    </ul>
+  </div>
+</header>
+<div class='main'>
+  <div class="container">
+    <% @users.each do |user| %>
+      <% if user.id == @user_relation.friend_id %>
+        <%= form_with model: @user_relation, url: user_user_relation_path(current_user.id, @user_relation.id), method: :patch, local: true do |f| %>
+          <h3><%= user.last_name %><%= user.first_name %>さんの紹介文を記入する</h3>
+          <%= f.text_area :friend_intrduction, placeholder: "紹介文を記入しましょう", rows: "10", cols: "100" %>
+          <%= f.submit "投稿する" %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -17,8 +17,8 @@
 </header>
 <div class='main'>
   <% if user_signed_in? %>
-    <h3>＜共通の友達一覧＞</h3>
-      <p>※一覧表示準備中※<br>もうしばらくお待ちください。。</p>
+    <%# <h3>＜共通の友達一覧＞</h3>
+      <p>※一覧表示準備中※<br>もうしばらくお待ちください。。</p> %>
     <h3>＜友達一覧＞</h3>
     <ul class='friend-list'>
     <% @user_relations.each do |user_relation| %>
@@ -26,9 +26,32 @@
         <li>
           <% @users.each do |user| %>
             <% if user.id == user_relation.friend_id %>
-              <p id= user_relations.friend_id>
+              <p id= user_relation_friend_id>
                 <%= user.last_name %> <%= user.first_name %>
-                <%= link_to '他己紹介を書く', '#', class:"#" %>
+                <% if user_relation.friend_introduction %>
+                  <%= link_to '他己紹介を更新する', edit_user_user_relation_path(user_id: user.id, id: user_relation.id), class:"edit-friend-introduction-btn" %>
+                  <br>
+                  投稿した紹介文：<%= user_relation.friend_introduction%>
+                <% else %>
+                  <%= link_to '他己紹介を書く', edit_user_user_relation_path(user_id: user.id, id: user_relation.id), class:"edit-friend-introduction-btn" %>
+                <% end %>
+              </p>
+            <% end %>
+          <% end %>
+        </li>
+      <% end %>
+    <% end %>
+    </ul>
+    <h3>＜友達が投稿した他己紹介一覧＞</h3>
+    <ul class='friend-list'>
+    <% @user_relations.each do |user_relation| %>
+      <% if current_user.id == user_relation.friend_id && user_relation.friend_introduction %>
+        <li>
+          <% @users.each do |user| %>
+            <% if user.id == user_relation.user_id %>
+              <p id=<% user_relation.id %>>
+                投稿者：<%= user.last_name %> <%= user.first_name %><br>
+                投稿した紹介文：<%= user_relation.friend_introduction%>
               </p>
             <% end %>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
   root to: 'users#index'
   resources :users, only: [:index] do
     resources :friend_approvals, only: [:create, :destroy]
-    resources :user_relations, only: [:create]
+    resources :user_relations, only: [:create, :edit, :update]
   end
 end


### PR DESCRIPTION
#what
他己紹介の投稿機能とユーザー一覧で紹介文を表示できるよう実装しました。
・他己紹介を見て、興味のあるユーザーを見つけられる様にするため。
・書いた文・書かれた文含め他己紹介分を閲覧できる様にするため。
#why
・第三者のユーザーから、どのような人物なのかわかるようにするため。
