### PR TITLE
共通の友人表示機能の実装

### DIFF
--- a/app/assets/stylesheets/user.css
+++ b/app/assets/stylesheets/user.css
@@ -138,10 +138,6 @@
 
 /* ヘッダー部分 */
 
-.top-page-header {
- 
-}
-
 * {
   box-sizing: border-box;
 }
@@ -208,7 +204,7 @@
   margin: 0 20vw;
 }
 
-.main li {
+.main ul li {
   text-decoration: none;
   color: #333333;
   list-style: none;
@@ -224,7 +220,7 @@
   border-radius: 20px;
 }
 
-.friend-name {
+.title-name {
   font-weight: bold;
   font-size: 18px;
   margin: 10px 0;
@@ -268,4 +264,8 @@
 
 .friend_request_name {
   width: 200px;
+}
+
+.friend-of-friends-introduction {
+  list-style: circle;
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,15 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!
   def index
     @users = User.all
     @friend_approvals = FriendApproval.all
     @user_relations = UserRelation.all
+    # カレントユーザーの友達の友達だが、カレントユーザーではなく、またカレントユーザーの友達でもないユーザー
+    query = "SELECT * FROM user_relations WHERE user_id IN(
+      SELECT friend_id FROM user_relations WHERE user_id = ?)
+      AND friend_id <> ?
+      AND friend_id NOT IN (SELECT friend_id FROM user_relations WHERE user_id = ?)"
+    @friend_of_friends = UserRelation.find_by_sql([query, current_user.id, current_user.id, current_user.id])
+    # binding.pry
   end
 end

--- a/app/views/devise/shared/_friend_approval_list.html.erb
+++ b/app/views/devise/shared/_friend_approval_list.html.erb
@@ -2,7 +2,7 @@
 <% @users.each do |user| %>
   <% if @friend_approvals.exists?(user_id: current_user.id, friend_id: user.id) %>
     <div class='friend-approval-box box'>
-      <p id= user.id><%= user.nickname %></p>
+      <p id=<%= user.id%>><%= user.nickname %></p>
     </div>
   <% end %>
 <% end %>

--- a/app/views/devise/shared/_friend_list.html.erb
+++ b/app/views/devise/shared/_friend_list.html.erb
@@ -4,13 +4,13 @@
     <div class='friend-box box'>
       <% @users.each do |user| %>
         <% if user.id == user_relation.friend_id %>
-          <p class='friend-name'>
+          <p class='title-name'>
             <%= user.last_name %> <%= user.first_name %>
           </p>
           <div class='introduction-header'>
             <p class='introduction-title'>＜紹介文＞</p>
             <% if user_relation.friend_introduction %>
-              <%= button_to '更新', edit_user_user_relation_path(user_id: user.id, id: user_relation.id), method: :get, class:"edit-friend-introduction-btn btn" %>
+              <%= button_to '更新する', edit_user_user_relation_path(user_id: user.id, id: user_relation.id), method: :get, class:"edit-friend-introduction-btn btn" %>
             <% else %>
               <%= button_to '新規作成', edit_user_user_relation_path(user_id: user.id, id: user_relation.id), method: :get, class:"edit-friend-introduction-btn btn" %>
             <% end %>

--- a/app/views/devise/shared/_friend_of_friends_list.html.erb
+++ b/app/views/devise/shared/_friend_of_friends_list.html.erb
@@ -1,0 +1,20 @@
+<div class='user-lists'>
+<% @users.each do |user| %>
+  <% if @friend_of_friends.pluck(:friend_id).include?(user.id) %>
+    <div class='user-box box'>
+      <p id=<%= user.id %> class='title-name'><%= user.nickname %></p>
+      <div class='introduction-header'>
+        <p class='introduction-title'>＜紹介文＞</p>
+        <%= button_to '友達申請する', user_friend_approvals_path(user.id), method: :post, class:"friend-Request-btn btn" %>
+      </div>
+      <% @friend_of_friends.each do |friend_of_friend| %>
+        <% if user.id == friend_of_friend.friend_id %>
+          <div class='friend-introduction'>
+            <li class='friend-of-friends-introduction'><%= friend_of_friend.friend_introduction %></li>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>
+</div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,8 +2,8 @@
 
 <div class='main'>
   <% if user_signed_in? %>
-    <%# <h3>＜共通の友達一覧＞</h3>
-      <p>※一覧表示準備中※<br>もうしばらくお待ちください。。</p> %>
+    <h3>共通の友達一覧</h3>
+    <%= render "devise/shared/friend_of_friends_list", locals: { user_relations: @user_relations, users: @users } %>
     <h3>友達一覧</h3>
     <%= render "devise/shared/friend_list", locals: { user_relations: @user_relations, users: @users } %>
     <h3>友達が投稿した他己紹介一覧</h3>


### PR DESCRIPTION
#what
共通の友人と紹介文を表示する機能を実装しました。
複数の友達が友達の友達と友達の場合、紹介文が複数表示されます。

#why
友達の友達とのつながりをつくるために必要なため。
友達の紹介文を閲覧できる様にすることで、信頼できる人からの視点でその人の性格や人となりを知ることができる様になります。